### PR TITLE
Update `cesko-digital-web` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mdx-js/react": "^1.6.6",
     "axios": "^0.21.0",
     "babel-plugin-styled-components": "^1.11.1",
-    "cesko-digital-web": "git+https://github.com/cesko-digital/web.git#rework",
+    "cesko-digital-web": "git+https://github.com/cesko-digital/web.git#last-gatsby",
     "dotenv": "^8.2.0",
     "gatsby": "2.32.8",
     "gatsby-image": "^2.11.0",


### PR DESCRIPTION
The builds have been during `yarn install` broken due to the rewrite of the `cesko-digital/web` repository into Next.js. The dependency has been updated to point to the tag containing the last commit before the rewrite.